### PR TITLE
fix Log4Shell CVE - CVE-2021-44228 or CVE-2021-45046

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:7.4.29-apache
 
 # Install extensions
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
Incorporated patch 492 from original repo.